### PR TITLE
Update chicago extraction script and workflow to enable date filtering and deduplication

### DIFF
--- a/.github/workflows/extract-chicago-permits.yaml
+++ b/.github/workflows/extract-chicago-permits.yaml
@@ -71,7 +71,8 @@ jobs:
         run: |
           pipenv run python3 permit_cleaning.py \
             '${{ inputs.start_date }}' \
-            '${{ inputs.end_date }}'
+            '${{ inputs.end_date }}' \
+            '${{ inputs.deduplicate }}'
         shell: bash
         working-directory: ${{ env.WORKING_DIR }}
         env:

--- a/.github/workflows/extract-chicago-permits.yaml
+++ b/.github/workflows/extract-chicago-permits.yaml
@@ -68,7 +68,10 @@ jobs:
           aws-region: us-east-1
 
       - name: Extract permits
-        run: pipenv run python3 permit_cleaning.py
+        run: |
+          pipenv run python3 permit_cleaning.py \
+            '${{ inputs.start_date }}' \
+            '${{ inputs.end_date }}'
         shell: bash
         working-directory: ${{ env.WORKING_DIR }}
         env:

--- a/chicago/permit_cleaning.py
+++ b/chicago/permit_cleaning.py
@@ -12,9 +12,10 @@ The following optional environment variables can be set:
     AWS_ATHENA_S3_STAGING_DIR: S3 path where Athena query results are stored
     AWS_REGION: Region that AWS operations should be run in
 
-The script also expects two positional arguments:
-    * start_date: The lower bound date to use for filtering permits
-    * end_date: The upper bound date to use for filtering
+The script also expects three positional arguments:
+    * start_date (str, YYYY-MM-DD): The lower bound date to use for filtering permits
+    * end_date (str, YYYY-MM-DD): The upper bound date to use for filtering
+    * deduplicate (bool): Whether to filter out permits that already exist in iasworld
 
 The following will also need to be updated:
     - At the beginning of each year: update year to current year in SQL_QUERY inside pull_existing_pins_from_athena() function


### PR DESCRIPTION
This PR updates the `extract-chicago-permits` workflow and associated Python script to read the values passed to the `start_date`, `end_date`, and `deduplicate` inputs, and use them to filter incoming permit data.

Logs for a successful workflow run: https://github.com/ccao-data/extract-permits/actions/runs/7467702318/job/20321702072#step:7:24

Closes #8 and #9.