### PR TITLE
Deduplicate PINs across PIN columns when cleaning Chicago permits

### DIFF
--- a/chicago/permit_cleaning.py
+++ b/chicago/permit_cleaning.py
@@ -84,6 +84,13 @@ def expand_multi_pin_permits(df):
     # keep rows with NA for pin1, filter out rows with NA for other pins
     melted_df = melted_df[(melted_df["pin_type"] == "pin1") | ((melted_df["pin_type"] != "pin1") & melted_df["solo_pin"].notna())]
 
+    # Sometimes the incoming permits have duplicate PINs across PIN
+    # columns, e.g. pin3 == pin4 and both are not null. Make sure to catch
+    # this edge case and remove the duplicate PINs from the set, giving
+    # priority to PINs with lower pin_types (e.g. if pin2 and pin3 share the
+    # same PIN, pin2 should take priority)
+    melted_df = melted_df.sort_values(by=["permit_", "solo_pin", "pin_type"]).drop_duplicates(subset=["permit_", "solo_pin"], keep="first")
+
     # order rows by permit number then pin type (so pins will be in order of their assigned numbering in permit table, not necessarily by pin number)
     melted_df = melted_df.sort_values(by=["permit_", "pin_type"]).reset_index(drop=True)
 


### PR DESCRIPTION
While performing the first production run of the `extract-chicago-permits` workflow, Will noticed that one permit in the source data had duplicate values across PIN columns:

![thumbnail_image001](https://github.com/ccao-data/extract-permits/assets/14170650/11a01e2c-903c-4097-aa7f-e09c7fd54416)

Our script isn't currently set up to handle this possibility, so it leads to duplicate rows being introduced to the output workbook. This PR implements an extra filtering step to deduplicate these PIN columns when formatting them so that each output row is unique.

In order to test this change, I ran the script in a small window around the date of the known duplicate permit on both the main and feature branches, and confirmed that the feature branch removed the duplicate permit:

```console
jeancochrane:~/code/extract-permits/chicago$ git checkout main
Switched to branch 'main'
Your branch is up to date with 'origin/main'.
jeancochrane:~/code/extract-permits/chicago$ pipenv run python3 permit_cleaning.py 2023-12-17 2023-12-19 false
Loading Chicago PIN universe data from csv.
Downloaded 148 permits between 2023-12-17 and 2023-12-19
# rows ready for upload:  167
# rows flagged for length:  0
# rows flagged for empty/invalid fields:  33
creating 1 xlsx files ready for SmartFile upload
jeancochrane:~/code/extract-permits/chicago$ git checkout jeancochrane/remove-duplicate-pins
Switched to branch 'jeancochrane/remove-duplicate-pins'
Your branch is up to date with 'origin/jeancochrane/remove-duplicate-pins'.
jeancochrane:~/code/extract-permits/chicago$ pipenv run python3 permit_cleaning.py 2023-12-17 2023-12-19 false
Loading Chicago PIN universe data from csv.
Downloaded 148 permits between 2023-12-17 and 2023-12-19
# rows ready for upload:  166
# rows flagged for length:  0
# rows flagged for empty/invalid fields:  33
creating 1 xlsx files ready for SmartFile upload
```

I also double-checked the database to see if there were more duplicates in the time period that Will used for the import, and I found two more based on the query. I confirmed that these changes remove the extra dupes as well, and I'm planning to inform Will of the dupes over email.