### PR TITLE
Fix applicant name warning and migrate to new open data asset schema

### DIFF
--- a/chicago/Pipfile
+++ b/chicago/Pipfile
@@ -8,7 +8,7 @@ requests = "2.31.*"
 pandas = "2.1.*"
 sodapy = "2.2.*"
 PyAthena = "3.0.*"
-XlsxWriter = "3.1.*"
+xlsxwriter = "3.2.*"
 
 [dev-packages]
 

--- a/chicago/Pipfile
+++ b/chicago/Pipfile
@@ -8,7 +8,7 @@ requests = "2.31.*"
 pandas = "2.1.*"
 sodapy = "2.2.*"
 PyAthena = "3.0.*"
-xlsxwriter = "3.2.*"
+XlsxWriter = "3.2.*"
 
 [dev-packages]
 

--- a/chicago/Pipfile.lock
+++ b/chicago/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "c59fc39217f202ca670f42d03663e716d7b6dadfc78b7f1fbec4936434538f83"
+            "sha256": "20ac3f19e35e2fd38919e9283b440582f85f6623cf6b9de63ba1c8663501ec26"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,27 +18,27 @@
     "default": {
         "boto3": {
             "hashes": [
-                "sha256:620f1eb3e18e780be58383b4a4e10db003d2314131190514153996032c8d932d",
-                "sha256:8d54fa3a9290020f9a7f488f9cbe821029de0af05a677751b12973a5f726a5e2"
+                "sha256:92726a5be7083fd62585f8de251251ec7e53f4c7ee69c9c3168873fe979ec511",
+                "sha256:d34d7efe608b98cc10cfb43983bd2c511eb32efd5780ef72b171a3e3325462ff"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==1.33.11"
+            "markers": "python_version >= '3.8'",
+            "version": "==1.34.152"
         },
         "botocore": {
             "hashes": [
-                "sha256:b14b328f902d120de0a09eaa657a9a701c0ceeb711197c2f01ef0523f855086c",
-                "sha256:b46227eb3fa9cfdc8f5a83920ef347e67adea8095830ed265a3373b13b54421f"
+                "sha256:8531eb0f8d3b7913df8b32ca96d415d3187de8681e4ac908657803eacc87ac54",
+                "sha256:e291e425e34e9fdcdf32d7c37fc099be057335b58cccabf5ee7c945322dbcd87"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==1.33.11"
+            "markers": "python_version >= '3.8'",
+            "version": "==1.34.152"
         },
         "certifi": {
             "hashes": [
-                "sha256:9b469f3a900bf28dc19b8cfbf8019bf47f7fdd1a65a1d4ffb98fc14166beb4d1",
-                "sha256:e036ab49d5b79556f99cfc2d9320b34cfbe5be05c5871b51de9329f0603b0474"
+                "sha256:5a1e7645bc0ec61a09e26c36f6106dd4cf40c6db3a1fb6352b0244e7fb057c7b",
+                "sha256:c198e21b1289c2ab85ee4e67bb4b4ef3ead0892059901a8d5b622f24a1101e90"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2023.11.17"
+            "version": "==2024.7.4"
         },
         "charset-normalizer": {
             "hashes": [
@@ -138,19 +138,19 @@
         },
         "fsspec": {
             "hashes": [
-                "sha256:6271f1d3075a378bfe432f6f42bf7e1d2a6ba74f78dd9b512385474c579146a0",
-                "sha256:c4da01a35ac65c853f833e43f67802c25213f560820d54ddf248f92eddd5e990"
+                "sha256:3cb443f8bcd2efb31295a5b9fdb02aee81d8452c80d28f97a6d0959e6cee101e",
+                "sha256:fad7d7e209dd4c1208e3bbfda706620e0da5142bebbd9c384afb95b07e798e49"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==2023.12.1"
+            "version": "==2024.6.1"
         },
         "idna": {
             "hashes": [
-                "sha256:9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca",
-                "sha256:c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f"
+                "sha256:028ff3aadf0609c1fd278d8ea3089299412a7a8b9bd005dd08b9f8285bcb5cfc",
+                "sha256:82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0"
             ],
             "markers": "python_version >= '3.5'",
-            "version": "==3.6"
+            "version": "==3.7"
         },
         "jmespath": {
             "hashes": [
@@ -162,45 +162,45 @@
         },
         "numpy": {
             "hashes": [
-                "sha256:06fa1ed84aa60ea6ef9f91ba57b5ed963c3729534e6e54055fc151fad0423f0a",
-                "sha256:174a8880739c16c925799c018f3f55b8130c1f7c8e75ab0a6fa9d41cab092fd6",
-                "sha256:1a13860fdcd95de7cf58bd6f8bc5a5ef81c0b0625eb2c9a783948847abbef2c2",
-                "sha256:1cc3d5029a30fb5f06704ad6b23b35e11309491c999838c31f124fee32107c79",
-                "sha256:22f8fc02fdbc829e7a8c578dd8d2e15a9074b630d4da29cda483337e300e3ee9",
-                "sha256:26c9d33f8e8b846d5a65dd068c14e04018d05533b348d9eaeef6c1bd787f9919",
-                "sha256:2b3fca8a5b00184828d12b073af4d0fc5fdd94b1632c2477526f6bd7842d700d",
-                "sha256:2beef57fb031dcc0dc8fa4fe297a742027b954949cabb52a2a376c144e5e6060",
-                "sha256:36340109af8da8805d8851ef1d74761b3b88e81a9bd80b290bbfed61bd2b4f75",
-                "sha256:3703fc9258a4a122d17043e57b35e5ef1c5a5837c3db8be396c82e04c1cf9b0f",
-                "sha256:3ced40d4e9e18242f70dd02d739e44698df3dcb010d31f495ff00a31ef6014fe",
-                "sha256:4a06263321dfd3598cacb252f51e521a8cb4b6df471bb12a7ee5cbab20ea9167",
-                "sha256:4eb8df4bf8d3d90d091e0146f6c28492b0be84da3e409ebef54349f71ed271ef",
-                "sha256:5d5244aabd6ed7f312268b9247be47343a654ebea52a60f002dc70c769048e75",
-                "sha256:64308ebc366a8ed63fd0bf426b6a9468060962f1a4339ab1074c228fa6ade8e3",
-                "sha256:6a3cdb4d9c70e6b8c0814239ead47da00934666f668426fc6e94cce869e13fd7",
-                "sha256:854ab91a2906ef29dc3925a064fcd365c7b4da743f84b123002f6139bcb3f8a7",
-                "sha256:94cc3c222bb9fb5a12e334d0479b97bb2df446fbe622b470928f5284ffca3f8d",
-                "sha256:96ca5482c3dbdd051bcd1fce8034603d6ebfc125a7bd59f55b40d8f5d246832b",
-                "sha256:a2bbc29fcb1771cd7b7425f98b05307776a6baf43035d3b80c4b0f29e9545186",
-                "sha256:a4cd6ed4a339c21f1d1b0fdf13426cb3b284555c27ac2f156dfdaaa7e16bfab0",
-                "sha256:aa18428111fb9a591d7a9cc1b48150097ba6a7e8299fb56bdf574df650e7d1f1",
-                "sha256:aa317b2325f7aa0a9471663e6093c210cb2ae9c0ad824732b307d2c51983d5b6",
-                "sha256:b04f5dc6b3efdaab541f7857351aac359e6ae3c126e2edb376929bd3b7f92d7e",
-                "sha256:b272d4cecc32c9e19911891446b72e986157e6a1809b7b56518b4f3755267523",
-                "sha256:b361d369fc7e5e1714cf827b731ca32bff8d411212fccd29ad98ad622449cc36",
-                "sha256:b96e7b9c624ef3ae2ae0e04fa9b460f6b9f17ad8b4bec6d7756510f1f6c0c841",
-                "sha256:baf8aab04a2c0e859da118f0b38617e5ee65d75b83795055fb66c0d5e9e9b818",
-                "sha256:bcc008217145b3d77abd3e4d5ef586e3bdfba8fe17940769f8aa09b99e856c00",
-                "sha256:bd3f0091e845164a20bd5a326860c840fe2af79fa12e0469a12768a3ec578d80",
-                "sha256:cc392fdcbd21d4be6ae1bb4475a03ce3b025cd49a9be5345d76d7585aea69440",
-                "sha256:d73a3abcac238250091b11caef9ad12413dab01669511779bc9b29261dd50210",
-                "sha256:f43740ab089277d403aa07567be138fc2a89d4d9892d113b76153e0e412409f8",
-                "sha256:f65738447676ab5777f11e6bbbdb8ce11b785e105f690bc45966574816b6d3ea",
-                "sha256:f79b231bf5c16b1f39c7f4875e1ded36abee1591e98742b05d8a0fb55d8a3eec",
-                "sha256:fe6b44fb8fcdf7eda4ef4461b97b3f63c466b27ab151bec2366db8b197387841"
+                "sha256:03a8c78d01d9781b28a6989f6fa1bb2c4f2d51201cf99d3dd875df6fbd96b23b",
+                "sha256:08beddf13648eb95f8d867350f6a018a4be2e5ad54c8d8caed89ebca558b2818",
+                "sha256:1af303d6b2210eb850fcf03064d364652b7120803a0b872f5211f5234b399f20",
+                "sha256:1dda2e7b4ec9dd512f84935c5f126c8bd8b9f2fc001e9f54af255e8c5f16b0e0",
+                "sha256:2a02aba9ed12e4ac4eb3ea9421c420301a0c6460d9830d74a9df87efa4912010",
+                "sha256:2e4ee3380d6de9c9ec04745830fd9e2eccb3e6cf790d39d7b98ffd19b0dd754a",
+                "sha256:3373d5d70a5fe74a2c1bb6d2cfd9609ecf686d47a2d7b1d37a8f3b6bf6003aea",
+                "sha256:47711010ad8555514b434df65f7d7b076bb8261df1ca9bb78f53d3b2db02e95c",
+                "sha256:4c66707fabe114439db9068ee468c26bbdf909cac0fb58686a42a24de1760c71",
+                "sha256:50193e430acfc1346175fcbdaa28ffec49947a06918b7b92130744e81e640110",
+                "sha256:52b8b60467cd7dd1e9ed082188b4e6bb35aa5cdd01777621a1658910745b90be",
+                "sha256:60dedbb91afcbfdc9bc0b1f3f402804070deed7392c23eb7a7f07fa857868e8a",
+                "sha256:62b8e4b1e28009ef2846b4c7852046736bab361f7aeadeb6a5b89ebec3c7055a",
+                "sha256:666dbfb6ec68962c033a450943ded891bed2d54e6755e35e5835d63f4f6931d5",
+                "sha256:675d61ffbfa78604709862923189bad94014bef562cc35cf61d3a07bba02a7ed",
+                "sha256:679b0076f67ecc0138fd2ede3a8fd196dddc2ad3254069bcb9faf9a79b1cebcd",
+                "sha256:7349ab0fa0c429c82442a27a9673fc802ffdb7c7775fad780226cb234965e53c",
+                "sha256:7ab55401287bfec946ced39700c053796e7cc0e3acbef09993a9ad2adba6ca6e",
+                "sha256:7e50d0a0cc3189f9cb0aeb3a6a6af18c16f59f004b866cd2be1c14b36134a4a0",
+                "sha256:95a7476c59002f2f6c590b9b7b998306fba6a5aa646b1e22ddfeaf8f78c3a29c",
+                "sha256:96ff0b2ad353d8f990b63294c8986f1ec3cb19d749234014f4e7eb0112ceba5a",
+                "sha256:9fad7dcb1aac3c7f0584a5a8133e3a43eeb2fe127f47e3632d43d677c66c102b",
+                "sha256:9ff0f4f29c51e2803569d7a51c2304de5554655a60c5d776e35b4a41413830d0",
+                "sha256:a354325ee03388678242a4d7ebcd08b5c727033fcff3b2f536aea978e15ee9e6",
+                "sha256:a4abb4f9001ad2858e7ac189089c42178fcce737e4169dc61321660f1a96c7d2",
+                "sha256:ab47dbe5cc8210f55aa58e4805fe224dac469cde56b9f731a4c098b91917159a",
+                "sha256:afedb719a9dcfc7eaf2287b839d8198e06dcd4cb5d276a3df279231138e83d30",
+                "sha256:b3ce300f3644fb06443ee2222c2201dd3a89ea6040541412b8fa189341847218",
+                "sha256:b97fe8060236edf3662adfc2c633f56a08ae30560c56310562cb4f95500022d5",
+                "sha256:bfe25acf8b437eb2a8b2d49d443800a5f18508cd811fea3181723922a8a82b07",
+                "sha256:cd25bcecc4974d09257ffcd1f098ee778f7834c3ad767fe5db785be9a4aa9cb2",
+                "sha256:d209d8969599b27ad20994c8e41936ee0964e6da07478d6c35016bc386b66ad4",
+                "sha256:d5241e0a80d808d70546c697135da2c613f30e28251ff8307eb72ba696945764",
+                "sha256:edd8b5fe47dab091176d21bb6de568acdd906d1887a4584a15a9a96a1dca06ef",
+                "sha256:f870204a840a60da0b12273ef34f7051e98c3b5961b61b0c2c1be6dfd64fbcd3",
+                "sha256:ffa75af20b44f8dba823498024771d5ac50620e6915abac414251bd971b4529f"
             ],
             "markers": "python_version < '3.11'",
-            "version": "==1.26.2"
+            "version": "==1.26.4"
         },
         "pandas": {
             "hashes": [
@@ -244,18 +244,18 @@
         },
         "python-dateutil": {
             "hashes": [
-                "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
-                "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+                "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3",
+                "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==2.8.2"
+            "version": "==2.9.0.post0"
         },
         "pytz": {
             "hashes": [
-                "sha256:7b4fddbeb94a1eba4b557da24f19fdf9db575192544270a9101d8509f9f43d7b",
-                "sha256:ce42d816b81b68506614c11e8937d3aa9e41007ceb50bfdcb0749b921bf646c7"
+                "sha256:2a29735ea9c18baf14b448846bde5a48030ed267578472d8955cd0e7443a9812",
+                "sha256:328171f4e3623139da4983451950b28e95ac706e13f3f2630a879749e7a8b319"
             ],
-            "version": "==2023.3.post1"
+            "version": "==2024.1"
         },
         "requests": {
             "hashes": [
@@ -268,11 +268,11 @@
         },
         "s3transfer": {
             "hashes": [
-                "sha256:368ac6876a9e9ed91f6bc86581e319be08188dc60d50e0d56308ed5765446283",
-                "sha256:c9e56cbe88b28d8e197cf841f1f0c130f246595e77ae5b5a05b69fe7cb83de76"
+                "sha256:0711534e9356d3cc692fdde846b4a1e4b0cb6519971860796e6bc4c7aea00ef6",
+                "sha256:eca1c20de70a39daee580aef4986996620f365c4e0fda6a86100231d62f1bf69"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==0.8.2"
+            "markers": "python_version >= '3.8'",
+            "version": "==0.10.2"
         },
         "six": {
             "hashes": [
@@ -292,35 +292,36 @@
         },
         "tenacity": {
             "hashes": [
-                "sha256:5398ef0d78e63f40007c1fb4c0bff96e1911394d2fa8d194f77619c05ff6cc8a",
-                "sha256:ce510e327a630c9e1beaf17d42e6ffacc88185044ad85cf74c0a8887c6a0f88c"
+                "sha256:807f37ca97d62aa361264d497b0e31e92b8027044942bfa756160d908320d73b",
+                "sha256:93de0c98785b27fcf659856aa9f54bfbd399e29969b0621bc7f762bd441b4539"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==8.2.3"
+            "markers": "python_version >= '3.8'",
+            "version": "==9.0.0"
         },
         "tzdata": {
             "hashes": [
-                "sha256:11ef1e08e54acb0d4f95bdb1be05da659673de4acbd21bf9c69e94cc5e907a3a",
-                "sha256:7e65763eef3120314099b6939b5546db7adce1e7d6f2e179e3df563c70511eda"
+                "sha256:2674120f8d891909751c38abcdfd386ac0a5a1127954fbc332af6b5ceae07efd",
+                "sha256:9068bc196136463f5245e51efda838afa15aaeca9903f49050dfa2679db4d252"
             ],
             "markers": "python_version >= '2'",
-            "version": "==2023.3"
+            "version": "==2024.1"
         },
         "urllib3": {
             "hashes": [
-                "sha256:c97dfde1f7bd43a71c8d2a58e369e9b2bf692d1334ea9f9cae55add7d0dd0f84",
-                "sha256:fdb6d215c776278489906c2f8916e6e7d4f5a9b602ccbcfdf7f016fc8da0596e"
+                "sha256:a448b2f64d686155468037e1ace9f2d2199776e17f0a46610480d311f73e3472",
+                "sha256:dd505485549a7a552833da5e6063639d0d177c04f23bc3864e41e5dc5f612168"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==2.0.7"
+            "markers": "python_version >= '3.8'",
+            "version": "==2.2.2"
         },
         "xlsxwriter": {
             "hashes": [
-                "sha256:b61c1a0c786f82644936c0936ec96ee96cd3afb9440094232f7faef9b38689f0",
-                "sha256:de810bf328c6a4550f4ffd6b0b34972aeb7ffcf40f3d285a0413734f9b63a929"
+                "sha256:9977d0c661a72866a61f9f7a809e25ebbb0fb7036baa3b9fe74afcfca6b3cb8c",
+                "sha256:ecfd5405b3e0e228219bcaf24c2ca0915e012ca9464a14048021d21a995d490e"
             ],
+            "index": "pypi",
             "markers": "python_version >= '3.6'",
-            "version": "==3.1.9"
+            "version": "==3.2.0"
         }
     },
     "develop": {}

--- a/chicago/Pipfile.lock
+++ b/chicago/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "20ac3f19e35e2fd38919e9283b440582f85f6623cf6b9de63ba1c8663501ec26"
+            "sha256": "208f2e6a2852cde93832af35bfe972f348e3c1ed5a2d49dd414320b613286d0d"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -319,7 +319,6 @@
                 "sha256:9977d0c661a72866a61f9f7a809e25ebbb0fb7036baa3b9fe74afcfca6b3cb8c",
                 "sha256:ecfd5405b3e0e228219bcaf24c2ca0915e012ca9464a14048021d21a995d490e"
             ],
-            "index": "pypi",
             "markers": "python_version >= '3.6'",
             "version": "==3.2.0"
         }

--- a/chicago/permit_cleaning.py
+++ b/chicago/permit_cleaning.py
@@ -71,7 +71,7 @@ def expand_multi_pin_permits(df):
     """
     Data from the Chicago open data permits table (data this script works with) has rows uniquely identified by permit number.
     Permits can apply to multiple PINs, in which case the PIN_LIST column will
-    be an pipe-separated value representing multiple PINs.
+    be a pipe-separated value representing multiple PINs.
     We want rows that are uniquely identified by PIN and permit number.
     This function creates new rows for each PIN in multi-PIN permits and saves the relevant PIN in pin_solo.
     """
@@ -107,7 +107,7 @@ def expand_multi_pin_permits(df):
 
     # Add a column to track the position of the PIN in the PIN list for
     # ordering, starting at 1
-    df["pin_type"] = df.groupby(level=0).cumcount() + 1
+    df["pin_type"] = df.groupby("permit_").cumcount() + 1
     df["pin_type"] = "pin" + df["pin_type"].astype(str)
 
     # Add back the NA rows

--- a/chicago/permit_cleaning.py
+++ b/chicago/permit_cleaning.py
@@ -142,7 +142,7 @@ def format_pin(df):
 # Eliminate columns not included in permit upload and rename and order to match Smartfile excel format
 def organize_columns(df):
 
-    address_columns = ["street_number", "street_direction", "street_name", "suffix"]
+    address_columns = ["street_number", "street_direction", "street_name"]
     df[address_columns] = df[address_columns].fillna("")
     df["Address"] = df[address_columns].astype("string").agg(" ".join, axis=1)
 

--- a/chicago/permit_cleaning.py
+++ b/chicago/permit_cleaning.py
@@ -245,7 +245,7 @@ def flag_fix_long_fields(df):
 
     for flag_name, column, limit, comment in long_fields_to_flag:
         df[flag_name] = df[column].apply(lambda val: 0 if pd.isna(val) else (1 if len(str(val)) > limit else 0))
-        df["FLAG COMMENTS"] += df[column].apply(lambda val: "" if pd.isna(val) else ("" if len(str(val)) < limit else comment + str(len(str(val)) - limit) + "; "))
+        df["FLAG COMMENTS"] += df[column].apply(lambda val: "" if pd.isna(val) else ("" if len(str(val)) <= limit else comment + str(len(str(val)) - limit) + "; "))
 
     # round Amount to closest dollar because smart file doesn't accept decimal amounts, then flag values above upper limit
     df["Amount* [AMOUNT]"] = pd.to_numeric(df["Amount* [AMOUNT]"], errors="coerce").round().astype("Int64")

--- a/chicago/permit_cleaning.py
+++ b/chicago/permit_cleaning.py
@@ -70,31 +70,55 @@ def download_permits(start_date, end_date):
 def expand_multi_pin_permits(df):
     """
     Data from the Chicago open data permits table (data this script works with) has rows uniquely identified by permit number.
-    Permits can apply to multiple PINs, with additional PINs recorded in the PIN2 - PIN10 fields.
+    Permits can apply to multiple PINs, in which case the PIN_LIST column will
+    be an pipe-separated value representing multiple PINs.
     We want rows that are uniquely identified by PIN and permit number.
-    This function creates new rows for each additional PIN in multi-PIN permits and saves the relevant PIN in pin_solo.
+    This function creates new rows for each PIN in multi-PIN permits and saves the relevant PIN in pin_solo.
     """
-    # the downloaded dataframe will not include any pin columns that are completely blank, so check for existing ones here
-    all_pin_columns = ["pin1", "pin2", "pin3", "pin4", "pin5", "pin6", "pin7", "pin8", "pin9", "pin10"]
-    pin_columns = [col for col in df.columns if col in all_pin_columns]
-    non_pin_columns = [col for col in df.columns if col not in pin_columns]
+    def parse_pin_list(pin_list_str):
+        """Parse the PIN_LIST column. The column is formatted like so:
 
-    melted_df = pd.melt(df, id_vars=non_pin_columns, value_vars=pin_columns, var_name="pin_type", value_name="solo_pin")
+          * If no PINs are in the list, the value is NA, and we want to keep it
+          * Otherwise, PINs are stored as pipe-separated values, and we want to
+            parse them as lists so that we can pivot them out to one
+            permit per PIN
+        """
+        if pd.isna(pin_list_str):
+            return np.nan
+        elif " | " in pin_list_str:
+            pin_list = pin_list_str.split(" | ")
+            # Remove duplicates while maintaining list order
+            return list(dict.fromkeys(pin_list))
+        else:
+            return [pin_list_str]
 
-    # keep rows with NA for pin1, filter out rows with NA for other pins
-    melted_df = melted_df[(melted_df["pin_type"] == "pin1") | ((melted_df["pin_type"] != "pin1") & melted_df["solo_pin"].notna())]
+    df['pin_list'] = df['pin_list'].apply(parse_pin_list)
 
-    # Sometimes the incoming permits have duplicate PINs across PIN
-    # columns, e.g. pin3 == pin4 and both are not null. Make sure to catch
-    # this edge case and remove the duplicate PINs from the set, giving
-    # priority to PINs with lower pin_types (e.g. if pin2 and pin3 share the
-    # same PIN, pin2 should take priority)
-    melted_df = melted_df.sort_values(by=["permit_", "solo_pin", "pin_type"]).drop_duplicates(subset=["permit_", "solo_pin"], keep="first")
+    # Retain rows where pin_list is NA, since the pivot operation will
+    # remove them but we want to keep them
+    na_rows = df[df["pin_list"].isna()]
+    df = df.dropna(subset=["pin_list"])
 
-    # order rows by permit number then pin type (so pins will be in order of their assigned numbering in permit table, not necessarily by pin number)
-    melted_df = melted_df.sort_values(by=["permit_", "pin_type"]).reset_index(drop=True)
+    # Pivot the dataframe longer by "pin_list" so that we have one row
+    # per PIN with "solo_pin" being the PIN column
+    df = df.explode("pin_list").reset_index(drop=True).rename(columns={
+        "pin_list": "solo_pin"
+    })
 
-    return melted_df
+    # Add a column to track the position of the PIN in the PIN list for
+    # ordering, starting at 1
+    df["pin_type"] = df.groupby(level=0).cumcount() + 1
+    df["pin_type"] = "pin" + df["pin_type"].astype(str)
+
+    # Add back the NA rows
+    df = pd.concat([df, na_rows], ignore_index=True)
+
+    # Sort by the permit number, then the position of the PIN in the list,
+    # so that PINs will be in order of their permit number and list position
+    # in the output table
+    df = df.sort_values(by=["permit_", "pin_type"]).reset_index(drop=True)
+
+    return df
 
 
 # update pin to match formatting of iasWorld


### PR DESCRIPTION
## Overview

This PR makes two main changes:

* Closes https://github.com/ccao-data/extract-permits/issues/16 by fixing an off-by-one error that was causing applicant names with exactly 50 characters to get flagged as being _over_ 50 characters
* Migrates the script to accommodate [changes to the open data asset schema](https://data.cityofchicago.org/stories/s/2mfe-wq8d) that were made in May 2024, namely:
    * Switching from ten `PIN_{X}` columns to one `PIN_LIST` column representing a pipe-separated list of up to 10 PINs
    * Dropping the `SUFFIX` column, which is now included as part of the `STREET_NAME` column

We also refresh the Python dependencies to keep them up to date.

## Testing

I tested these changes by running the following extract job locally and inspecting the output to make sure A) the correct number of permits were extracted and B) the extract looks correct:

```
$ python3 permit_cleaning.py 2024-07-30 2024-08-02 False
```

Here's the console output confirming that 408 rows were extracted and converted to 410 PIN/permit combos (two rows had two values in the `PIN_LIST` column):

```
Loading Chicago PIN universe data from csv.
Downloaded 408 permits between 2024-07-30 and 2024-08-02
# rows ready for upload:  196
# rows flagged for length:  0
# rows flagged for empty/invalid fields:  214
creating 1 xlsx files ready for SmartFile upload
```

I'm happy to share the spreadsheet if you'd like to double check it yourself, too!