### PR TITLE
Update workflow and add docs to ensure we install Python dependencies from lockfiles

### DIFF
--- a/.github/workflows/extract-chicago-permits.yaml
+++ b/.github/workflows/extract-chicago-permits.yaml
@@ -33,7 +33,7 @@ env:
   WORKING_DIR: chicago
   S3_BUCKET: ccao-data-public-us-east-1
   S3_PREFIX: permits/chicago
-  UV_SYSTEM_PYTHON: 1
+  UV_FROZEN: "1"
   PYTHONUNBUFFERED: "1"
 
 jobs:
@@ -60,7 +60,7 @@ jobs:
           python-version-file: ${{ env.WORKING_DIR }}/.python-version
 
       - name: Install Python requirements
-        run: uv pip install .
+        run: uv sync
         shell: bash
         working-directory: ${{ env.WORKING_DIR }}
 
@@ -72,7 +72,8 @@ jobs:
 
       - name: Extract permits
         run: |
-          python3 permit_cleaning.py \
+          uv run \
+            python3 permit_cleaning.py \
             '${{ inputs.start_date }}' \
             '${{ inputs.end_date }}' \
             '${{ inputs.deduplicate }}'

--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@ click the **Run workflow** button to open a dropdown, and select your parameters
   not extensively tested the deduplication logic. Instead, we only query
   mutually-exclusive date ranges of permits to send to the Data Integrity team.
 
+Once the workflow finishes running, it will upload a ZIP archive containing the
+permits to an AWS S3 bucket. It will also send a message containing a link to
+the bucket to an AWS SNS topic dedicated to the workflow. If you subscribe to
+that AWS SNS topic, you will receive an email with this link when the workflow
+has finished running. Alternatively, the workflow will also print a link to the
+S3 bucket in its logs, so you can check the logs instead of subscribing to
+the SNS topic.
+
 ## Development
 
 Follow these instructions if you need to make changes to the permit extraction

--- a/README.md
+++ b/README.md
@@ -1,3 +1,84 @@
 # extract-permits
 
 Scripts and workflows for permit data extraction.
+
+Currently, the only permits we extract are from the City of Chicago data
+portal. The code that extracts these permits is defined in the [`chicago/`
+subdirectory](./chicago/) and forms the basis of the
+[`extract-chicago-permits`
+workflow](https://github.com/ccao-data/extract-permits/actions/workflows/extract-chicago-permits.yaml).
+
+## Running the workflow
+
+To run the workflow, navigate to [the page for the
+workflow](https://github.com/ccao-data/extract-permits/actions/workflows/extract-chicago-permits.yaml),
+click the **Run workflow** button to open a dropdown, and select your parameters:
+
+- **Use workflow from**: The git branch to use as the basis for running the
+  workflow. Unless you are testing changes, this should always be `main`.
+- **Start date**: The lower bound (inclusive) for a date range to use to filter
+  permits. Must be in `YYYY-MM-DD` format.
+- **End date**: The upper bound (inclusive) for a date range to use to filter
+  permits. Must be in `YYYY-MM-DD` format.
+- **Deduplicate**: Filter out permits that have already been extracted to our
+  data warehouse. We recommend leaving this option unchecked because we have
+  not extensively tested the deduplication logic. Instead, we only query
+  mutually-exclusive date ranges of permits to send to the Data Integrity team.
+
+## Development
+
+Follow these instructions if you need to make changes to the permit extraction
+scripts.
+
+These instructions are for Ubuntu, which is the only platform we've tested.
+
+### Installation
+
+#### Requirements
+
+* Python3 with `uv` installed (pre-installed on the CCAO server)
+* [AWS CLI installed
+  locally](https://github.com/ccao-data/wiki/blob/master/How-To/Connect-to-AWS-Resources.md)
+  * You'll also need permissions for Athena, Glue, and S3
+* [`aws-mfa` installed locally](https://github.com/ccao-data/wiki/blob/master/How-To/Setup-the-AWS-Command-Line-Interface-and-Multi-factor-Authentication.md)
+
+#### Install Python dependencies
+
+Run the following commands to install Python dependencies:
+
+```bash
+cd chicago
+uv sync --frozen
+```
+
+### Run the script
+
+To run the script, make sure you're in the `chicago/` subdirectory:
+
+```bash
+cd chicago
+```
+
+You must also authenticate with AWS using MFA if you haven't already today:
+
+```bash
+aws-mfa
+```
+
+Then, run the script:
+
+```bash
+uv run python3 permit_cleaning.py \
+  # The first argument is the lower bound for the date range (inclusive)
+  <YYYY-MM-DD> \
+  # The second argument is the upper bound for the date range (inclusive)
+  <YYYY-MM-DD> \
+  # Boolean indicating whether to filter out permits that are already in
+  # our warehouse. We recommend not deduplicating because the logic has
+  # not been extensively tested
+  False
+```
+
+You can also run the script using the `extract-chicago-permits` workflow. See
+[Running the workflow](#running-the-workflow) for instructions on how to do
+that.


### PR DESCRIPTION
## Background

As we found in https://github.com/ccao-data/homeval/pull/158 and https://github.com/ccao-data/homeval/pull/162, the way we use `uv pip install` in the `extract-chicago-permits` workflow will cause uv to ignore `chicago/uv.lock` when installing dependencies. Instead, uv will decide which dependency versions to install based on `chicago/pyproject.toml`, but the dependencies in that config file are not locked to specific versions and hashes like they are in `uv.lock`.

This PR updates the `extract-chicago-permits` workflow to use uv commands that will ensure we use the exact versions of packages pinned in `chicago/uv.lock`. While I was here, I also took a minute to document how to install packages, how to run the script, and how to run the workflow in this repo.

Closes https://github.com/ccao-data/extract-permits/issues/6.

## Testing

I tested the new docs instructions by using them to recreate my dev environment and run a test of the script:

```bash
cd chicago
rm -rf .venv
uv sync --frozen
uv run python3 permit_cleaning.py 2026-05-01 2026-05-15 False
```

I also ran the same command using the workflow to confirm that it still works: https://github.com/ccao-data/extract-permits/actions/runs/25885258060/job/76075103623