### PR TITLE
Modify permit extraction script to return 2 files: Review and upload

### DIFF
--- a/.github/workflows/extract-chicago-permits.yaml
+++ b/.github/workflows/extract-chicago-permits.yaml
@@ -87,7 +87,7 @@ jobs:
         run: |
           ZIP_FILENAME="chicago-permits-$(date +%Y%m%d%H%M%S).zip"
           mkdir chicago-permits
-          mv files_for_* chicago-permits/
+          mv formatted_permits_* chicago-permits/
           zip -r "$ZIP_FILENAME" chicago-permits
           echo "filename=$ZIP_FILENAME" >> "$GITHUB_OUTPUT"
         shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -160,5 +160,5 @@ cython_debug/
 #.idea/
 
 # Ignore generated data
-chicago/files_for_*
+chicago/formatted_permits_*
 chicago/chicago_pin_universe*.csv

--- a/chicago/permit_cleaning.py
+++ b/chicago/permit_cleaning.py
@@ -120,7 +120,11 @@ FORMAT_HYPERLINK_UNLOCKED = {**_unlocked, **_hyperlink}
 #   python_validator (callable, optional)
 #       A lambda(row_series, colname) -> bool that returns True if this column's
 #       value in the given DataFrame row would trigger any clause in
-#       error_formula. This runs in parallel to the error_formula and should be
+#       error_formula. Uses the same (row, col) interface as error_formula:
+#       `col` is passed automatically from col_def["src"] by partition_permits,
+#       so lambdas should reference `col` rather than hardcoding the column name.
+#       This way a rename to the `src` key propagates here without a separate
+#       manual update. This runs in parallel to the error_formula and should be
 #       updated whenever those formulas are updated.
 #
 #   validation (dict, optional)
@@ -839,56 +843,48 @@ def deduplicate_permits(cursor, df, start_date, end_date):
         for col in PERMIT_COLUMNS.values()
         if col.get("src") and col.get("iasworld_name")
     }
-    new_permits = df.copy()
+    iasworld_cols = list(workbook_to_iasworld_col_map.values())
 
-    # Stash the original amount before transformation. The iasworld-formatted
-    # copy is used only for the deduplication join; because "amount" maps to
-    # itself. Without this, it returns NULL values when deduplicating.
-    original_amount = new_permits["amount"].copy()
-
-    for workbook_key, iasworld_key in workbook_to_iasworld_col_map.items():
-        new_permits[iasworld_key] = new_permits[workbook_key]
-
-    # Transform new columns to ensure they match the iasworld formatting
-    new_permits["amount"] = new_permits["amount"].apply(
+    # Build a join-key DataFrame with iasworld column names and formatting.
+    # Using a separate DataFrame (rather than adding columns to df) avoids
+    # name collisions when a src name equals its iasworld_name (e.g. "amount").
+    join_keys = pd.DataFrame(
+        {
+            iasworld: df[src]
+            for src, iasworld in workbook_to_iasworld_col_map.items()
+        }
+    )
+    join_keys["amount"] = join_keys["amount"].apply(
         lambda x: decimal.Decimal("{:.2f}".format(x))
         if not pd.isnull(x)
         else x
     )
-    new_permits["permdt"] = (
-        pd.to_datetime(new_permits["permdt"], dayfirst=False)
+    join_keys["permdt"] = (
+        pd.to_datetime(join_keys["permdt"], dayfirst=False)
         .dt.strftime("%Y-%m-%d %H:%M:%S.%f")
         .str[:-3]
     )
-    new_permits["note2"] = new_permits["note2"] + ",,CHICAGO, IL"
-    new_permits["user43"] = (
-        new_permits["user43"]
+    join_keys["note2"] = join_keys["note2"] + ",,CHICAGO, IL"
+    join_keys["user43"] = (
+        join_keys["user43"]
         # Replace special characters that Smartfile removes
         .str.replace(r"""[():;+#*&'"@½]""", "", regex=True)
         # Truncate description to match Smartfile length limit
         .str.slice(0, 259)
     )
 
-    # Antijoin new_permits to existing_permits to find permits that do
-    # not exist in iasworld
-    merged_permits = pd.merge(
-        new_permits,
-        existing_permits,
+    # Antijoin: drop_duplicates on the right side ensures each row in
+    # join_keys appears exactly once in the merge result, so the boolean
+    # mask aligns directly with df.
+    merged = pd.merge(
+        join_keys,
+        existing_permits[iasworld_cols].drop_duplicates(),
         how="left",
-        on=list(workbook_to_iasworld_col_map.values()),
+        on=iasworld_cols,
         indicator=True,
     )
-    true_new_permits = merged_permits[merged_permits["_merge"] == "left_only"]
-    true_new_permits = true_new_permits.drop("_merge", axis=1)
-    for iasworld_key in workbook_to_iasworld_col_map.values():
-        true_new_permits = true_new_permits.drop(iasworld_key, axis=1)
-
-    # Restore the original amount values.
-    true_new_permits["amount"] = original_amount.reindex(
-        true_new_permits.index
-    )
-
-    return true_new_permits
+    is_new = (merged["_merge"] == "left_only").values
+    return df[is_new].reset_index(drop=True)
 
 
 def gen_file_base_name(start_date, end_date):

--- a/chicago/permit_cleaning.py
+++ b/chicago/permit_cleaning.py
@@ -364,6 +364,7 @@ PERMIT_COLUMNS = {
         "header": "Applicant",
         "src": "applicant",
         "city_name": "contact_1_name",
+        "iasworld_name": "user21",
         "width": 35,
         "fmt": FORMAT_UNLOCKED_WRAP,
         "cell_type": "normal",
@@ -823,10 +824,10 @@ def deduplicate_permits(cursor, df, start_date, end_date):
                 parid,
                 permdt,
                 amount,
-                note2,
-                user21,
-                user28,
-                user43
+                note2,   -- applicant street address
+                user21,  -- applicant
+                user28,  -- local permit number
+                user43   -- work description
             FROM iasworld.permit
             WHERE permdt BETWEEN %(start_date)s AND %(end_date)s
         """,
@@ -842,7 +843,7 @@ def deduplicate_permits(cursor, df, start_date, end_date):
     iasworld_cols = list(workbook_to_iasworld_col_map.values())
 
     # Build a join-key DataFrame with iasworld column names and formatting.
-    # Using a separate DataFrame  avoids name collisions when a src name
+    # Using a separate DataFrame avoids name collisions when a src name
     # equals its iasworld_name (e.g. "amount").
     join_keys = pd.DataFrame(
         {

--- a/chicago/permit_cleaning.py
+++ b/chicago/permit_cleaning.py
@@ -175,9 +175,9 @@ PERMIT_COLUMNS = {
         ),
         # PIN universe membership is checked separately in
         # partition_permits() because it requires external universe_df.
-        "python_validator": lambda r: (
-            not str(r.get("pin") or "").strip()
-            or len(str(r.get("pin") or "").replace("-", "")) != 14
+        "python_validator": lambda r, col: (
+            not str(r.get(col) or "").strip()
+            or len(str(r.get(col) or "").replace("-", "")) != 14
         ),
         "validation": {
             "validate": "custom",
@@ -234,9 +234,9 @@ PERMIT_COLUMNS = {
             f'IF(LEN(TRIM({col}{row}))=0, "Missing Applicant Street Address", ""), '
             f'IF(LEN({col}{row})>40, "Address > 40 characters", "")'
         ),
-        "python_validator": lambda r: (
-            not str(r.get("applicant_street_address") or "").strip()
-            or len(str(r.get("applicant_street_address") or "")) > 40
+        "python_validator": lambda r, col: (
+            not str(r.get(col) or "").strip()
+            or len(str(r.get(col) or "")) > 40
         ),
         "validation": {
             "validate": "text length",
@@ -261,9 +261,7 @@ PERMIT_COLUMNS = {
         "error_formula": lambda row, col: (
             f'IF(LEN(TRIM({col}{row}))=0, "Missing Permit Number", "")'
         ),
-        "python_validator": lambda r: not str(
-            r.get("permit_no") or ""
-        ).strip(),
+        "python_validator": lambda r, col: not str(r.get(col) or "").strip(),
     },
     "issue_date": {
         "col_idx": 7,
@@ -277,9 +275,7 @@ PERMIT_COLUMNS = {
         "error_formula": lambda row, col: (
             f'IF(OR(NOT(ISNUMBER({col}{row})), {col}{row}=""), "Missing or Invalid Issue Date", "")'
         ),
-        "python_validator": lambda r: not str(
-            r.get("issue_date") or ""
-        ).strip(),
+        "python_validator": lambda r, col: not str(r.get(col) or "").strip(),
         "validation": {
             "validate": "date",
             "criteria": "greater than or equal to",
@@ -304,10 +300,10 @@ PERMIT_COLUMNS = {
             f'IF(AND(ISNUMBER({col}{row}), {col}{row}<1), "Amount must be at least 1", ""), '
             f'IF(AND(ISNUMBER({col}{row}), {col}{row}>2147483647), "Amount must be less than 2,147,483,647", "")'
         ),
-        "python_validator": lambda r: (
-            pd.isna(r.get("amount"))
-            or not str(r.get("amount") or "").strip()
-            or not (1 <= float(r.get("amount", 1)) <= 2147483647)
+        "python_validator": lambda r, col: (
+            pd.isna(r.get(col))
+            or not str(r.get(col) or "").strip()
+            or not (1 <= float(r.get(col, 1)) <= 2147483647)
         ),
         "validation": {
             "validate": "custom",
@@ -348,9 +344,9 @@ PERMIT_COLUMNS = {
             f'IF(LEN(TRIM({col}{row}))=0, "Missing Work Description", ""), '
             f'IF(LEN({col}{row})>2000, "Work Description > 2000 characters", "")'
         ),
-        "python_validator": lambda r: (
-            not str(r.get("work_description") or "").strip()
-            or len(str(r.get("work_description") or "")) > 2000
+        "python_validator": lambda r, col: (
+            not str(r.get(col) or "").strip()
+            or len(str(r.get(col) or "")) > 2000
         ),
         "validation": {
             "validate": "text length",
@@ -375,9 +371,9 @@ PERMIT_COLUMNS = {
             f'IF(LEN(TRIM({col}{row}))=0, "Missing Applicant", ""), '
             f'IF(LEN({col}{row})>50, "Applicant Name > 50 characters", "")'
         ),
-        "python_validator": lambda r: (
-            not str(r.get("applicant") or "").strip()
-            or len(str(r.get("applicant") or "")) > 50
+        "python_validator": lambda r, col: (
+            not str(r.get(col) or "").strip()
+            or len(str(r.get(col) or "")) > 50
         ),
         "validation": {
             "validate": "text length",
@@ -443,7 +439,7 @@ def partition_permits(
     def row_has_error(row):
         for col_def in PERMIT_COLUMNS_BY_IDX:
             validator = col_def.get("python_validator")
-            if validator and validator(row):
+            if validator and validator(row, col_def["src"]):
                 return True
         # PIN universe check (mirrors the third IF in pin's error_formula)
         pin_val = str(row.get("pin") or "").replace("-", "").zfill(14)
@@ -920,7 +916,7 @@ def _build_textjoin_errors_formula(row: int) -> str:
     return f'=_xlfn.TEXTJOIN(", ", TRUE, {clauses})'
 
 
-def save_xlsx_files(df, file_name, chicago_pin_universe, checked=False):
+def save_xlsx_file(df, file_name, chicago_pin_universe, checked=False):
     """Write one workbook to `file_name` containing a Permits sheet and a
     Universe of Valid PINs sheet.  When `checked` is True, all Ready
     checkboxes are pre-checked in the upload file."""
@@ -1219,14 +1215,14 @@ if __name__ == "__main__":
     )
 
     output_folder = (
-        datetime.today().date().strftime("files_for_review_%Y_%m_%d")
+        datetime.today().date().strftime("formatted_permits_%Y_%m_%d")
     )
     os.makedirs(output_folder, exist_ok=True)
 
     base = f"{start_date}_to_{end_date}_chicago_"
 
     print(f"Writing upload file ({len(upload_df)} rows):")
-    save_xlsx_files(
+    save_xlsx_file(
         upload_df,
         os.path.join(output_folder, f"upload_{base}permits.xlsx"),
         chicago_pin_universe,
@@ -1234,7 +1230,7 @@ if __name__ == "__main__":
     )
 
     print(f"Writing review file ({len(review_df)} rows):")
-    save_xlsx_files(
+    save_xlsx_file(
         review_df,
         os.path.join(output_folder, f"review_{base}permits.xlsx"),
         chicago_pin_universe,

--- a/chicago/permit_cleaning.py
+++ b/chicago/permit_cleaning.py
@@ -114,17 +114,14 @@ FORMAT_HYPERLINK_UNLOCKED = {**_unlocked, **_hyperlink}
 #       (comma-separated) to include in the TEXTJOIN Errors formula for this
 #       column. Each clause should evaluate to an error message string or "".
 #       Omit if no per-cell validation is needed for this column.
+#       This runs in parallel to the python_validator and should be updated
+#       whenever those formulas are updated.
 #
 #   python_validator (callable, optional)
 #       A lambda(row_series) -> bool that returns True if this column's value
 #       in the given DataFrame row would trigger any clause in error_formula.
-#       Used by partition_permits() to split rows into upload vs. review files
-#       without re-implementing logic separately from error_formula. The two
-#       callables should always agree: if error_formula would produce a non-empty
-#       string for a cell, python_validator must return True for that row.
-#       Omit for columns that have no error_formula or whose errors cannot be
-#       checked without external state (e.g. PIN universe lookup, handled
-#       directly in partition_permits).
+#       This runs in parallel to the error_formula and should be updated
+#       whenever those formulas are updated.
 #
 #   validation (dict, optional)
 #       An xlsxwriter data_validation() options dict to apply to the column's
@@ -176,8 +173,8 @@ PERMIT_COLUMNS = {
             f'IF(LEN(SUBSTITUTE({col}{row},"-",""))<>14, "PIN is not 14 digits", ""), '
             f'IF(OR(COUNTIF(\'Universe of Valid PINs\'!A:A,SUBSTITUTE({col}{row},"-","")),COUNTIF(\'Universe of Valid PINs\'!B:B,{col}{row})), "", "PIN is invalid")'
         ),
-        # PIN universe membership (third IF above) is checked separately in
-        # partition_permits() because it requires external state (the universe df).
+        # PIN universe membership is checked separately in
+        # partition_permits() because it requires external universe_df.
         "python_validator": lambda r: (
             not str(r.get("pin") or "").strip()
             or len(str(r.get("pin") or "").replace("-", "")) != 14
@@ -433,10 +430,9 @@ FREEZE_COLS = 3
 def partition_permits(df: pd.DataFrame, chicago_pin_universe: pd.DataFrame):
     """Split df into (upload_df, review_df) based on whether each row passes
     all validations.  Derives checks from the python_validator key in each
-    PERMIT_COLUMNS entry so there is a single source of truth with error_formula.
-    Rows that pass every check go to upload_df; rows with any failure go to
-    review_df. PIN universe membership (the third IF in pin's error_formula)
-    requires external state, so it is checked here rather than in python_validator.
+    PERMIT_COLUMNS.
+    Rows that pass every check and the pin_universe match go to upload_df;
+    rows with any failure go to review_df.
     """
     valid_pins = set(chicago_pin_universe["pin"].astype(str).str.zfill(14))
 
@@ -847,8 +843,7 @@ def deduplicate_permits(cursor, df, start_date, end_date):
 
     # Stash the original amount before transformation. The iasworld-formatted
     # copy is used only for the deduplication join; because "amount" maps to
-    # itself (src == iasworld_name), it would otherwise be dropped along with
-    # the other iasworld join columns at the end of this function.
+    # itself. Without this, it returns NULL values when deduplicating.
     original_amount = new_permits["amount"].copy()
 
     for workbook_key, iasworld_key in workbook_to_iasworld_col_map.items():
@@ -888,8 +883,7 @@ def deduplicate_permits(cursor, df, start_date, end_date):
     for iasworld_key in workbook_to_iasworld_col_map.values():
         true_new_permits = true_new_permits.drop(iasworld_key, axis=1)
 
-    # Restore the original amount values (integer dollars) now that the
-    # iasworld-formatted "amount" column has been dropped above.
+    # Restore the original amount values.
     true_new_permits["amount"] = original_amount.reindex(
         true_new_permits.index
     )
@@ -925,7 +919,7 @@ def _build_textjoin_errors_formula(row: int) -> str:
 def save_xlsx_files(df, file_name, chicago_pin_universe, checked=False):
     """Write one workbook to `file_name` containing a Permits sheet and a
     Universe of Valid PINs sheet.  When `checked` is True, all Ready
-    checkboxes are pre-checked (used for the upload file)."""
+    checkboxes are pre-checked in the upload file."""
     df_all = df.reset_index(drop=True)
 
     print(f"  # rows: {len(df_all)}")

--- a/chicago/permit_cleaning.py
+++ b/chicago/permit_cleaning.py
@@ -846,8 +846,8 @@ def deduplicate_permits(cursor, df, start_date, end_date):
     iasworld_cols = list(workbook_to_iasworld_col_map.values())
 
     # Build a join-key DataFrame with iasworld column names and formatting.
-    # Using a separate DataFrame (rather than adding columns to df) avoids
-    # name collisions when a src name equals its iasworld_name (e.g. "amount").
+    # Using a separate DataFrame  avoids name collisions when a src name
+    # equals its iasworld_name (e.g. "amount").
     join_keys = pd.DataFrame(
         {
             iasworld: df[src]
@@ -874,8 +874,7 @@ def deduplicate_permits(cursor, df, start_date, end_date):
     )
 
     # Antijoin: drop_duplicates on the right side ensures each row in
-    # join_keys appears exactly once in the merge result, so the boolean
-    # mask aligns directly with df.
+    # join_keys appears exactly once in the merge result.
     merged = pd.merge(
         join_keys,
         existing_permits[iasworld_cols].drop_duplicates(),

--- a/chicago/permit_cleaning.py
+++ b/chicago/permit_cleaning.py
@@ -307,7 +307,7 @@ PERMIT_COLUMNS = {
         "python_validator": lambda r: (
             pd.isna(r.get("amount"))
             or not str(r.get("amount") or "").strip()
-            or not (1 <= float(r["amount"]) <= 2147483647)
+            or not (1 <= float(r.get("amount", 1)) <= 2147483647)
         ),
         "validation": {
             "validate": "custom",
@@ -427,12 +427,17 @@ PERMIT_COLUMNS_BY_IDX = sorted(
 FREEZE_COLS = 3
 
 
-def partition_permits(df: pd.DataFrame, chicago_pin_universe: pd.DataFrame):
+def partition_permits(
+    df: pd.DataFrame,
+    chicago_pin_universe: pd.DataFrame
+) -> tuple[pd.DataFrame, pd.DataFrame]:
     """Split df into (upload_df, review_df) based on whether each row passes
     all validations.  Derives checks from the python_validator key in each
     PERMIT_COLUMNS.
-    Rows that pass every check and the pin_universe match go to upload_df;
-    rows with any failure go to review_df.
+    Rows that pass every check and the pin_universe match will be present in the
+    dataframe that comprises the first element of the returned tuple; rows with
+    any failures will be present as part of the dataframe in the second
+    element.
     """
     valid_pins = set(chicago_pin_universe["pin"].astype(str).str.zfill(14))
 
@@ -1234,4 +1239,5 @@ if __name__ == "__main__":
         review_df,
         os.path.join(output_folder, f"review_{base}permits.xlsx"),
         chicago_pin_universe,
+        checked=False,
     )

--- a/chicago/permit_cleaning.py
+++ b/chicago/permit_cleaning.py
@@ -120,11 +120,7 @@ FORMAT_HYPERLINK_UNLOCKED = {**_unlocked, **_hyperlink}
 #   python_validator (callable, optional)
 #       A lambda(row_series, colname) -> bool that returns True if this column's
 #       value in the given DataFrame row would trigger any clause in
-#       error_formula. Uses the same (row, col) interface as error_formula:
-#       `col` is passed automatically from col_def["src"] by partition_permits,
-#       so lambdas should reference `col` rather than hardcoding the column name.
-#       This way a rename to the `src` key propagates here without a separate
-#       manual update. This runs in parallel to the error_formula and should be
+#       error_formula. This runs in parallel to the error_formula and should be
 #       updated whenever those formulas are updated.
 #
 #   validation (dict, optional)

--- a/chicago/permit_cleaning.py
+++ b/chicago/permit_cleaning.py
@@ -115,6 +115,17 @@ FORMAT_HYPERLINK_UNLOCKED = {**_unlocked, **_hyperlink}
 #       column. Each clause should evaluate to an error message string or "".
 #       Omit if no per-cell validation is needed for this column.
 #
+#   python_validator (callable, optional)
+#       A lambda(row_series) -> bool that returns True if this column's value
+#       in the given DataFrame row would trigger any clause in error_formula.
+#       Used by partition_permits() to split rows into upload vs. review files
+#       without re-implementing logic separately from error_formula. The two
+#       callables should always agree: if error_formula would produce a non-empty
+#       string for a cell, python_validator must return True for that row.
+#       Omit for columns that have no error_formula or whose errors cannot be
+#       checked without external state (e.g. PIN universe lookup, handled
+#       directly in partition_permits).
+#
 #   validation (dict, optional)
 #       An xlsxwriter data_validation() options dict to apply to the column's
 #       data range. The special placeholders {COL} and {ERRORS_COL} in the
@@ -164,6 +175,12 @@ PERMIT_COLUMNS = {
             f'IF(LEN(TRIM({col}{row}))=0, "Missing PIN", ""), '
             f'IF(LEN(SUBSTITUTE({col}{row},"-",""))<>14, "PIN is not 14 digits", ""), '
             f'IF(OR(COUNTIF(\'Universe of Valid PINs\'!A:A,SUBSTITUTE({col}{row},"-","")),COUNTIF(\'Universe of Valid PINs\'!B:B,{col}{row})), "", "PIN is invalid")'
+        ),
+        # PIN universe membership (third IF above) is checked separately in
+        # partition_permits() because it requires external state (the universe df).
+        "python_validator": lambda r: (
+            not str(r.get("pin") or "").strip()
+            or len(str(r.get("pin") or "").replace("-", "")) != 14
         ),
         "validation": {
             "validate": "custom",
@@ -220,6 +237,10 @@ PERMIT_COLUMNS = {
             f'IF(LEN(TRIM({col}{row}))=0, "Missing Applicant Street Address", ""), '
             f'IF(LEN({col}{row})>40, "Address > 40 characters", "")'
         ),
+        "python_validator": lambda r: (
+            not str(r.get("applicant_street_address") or "").strip()
+            or len(str(r.get("applicant_street_address") or "")) > 40
+        ),
         "validation": {
             "validate": "text length",
             "criteria": "between",
@@ -243,6 +264,9 @@ PERMIT_COLUMNS = {
         "error_formula": lambda row, col: (
             f'IF(LEN(TRIM({col}{row}))=0, "Missing Permit Number", "")'
         ),
+        "python_validator": lambda r: not str(
+            r.get("permit_no") or ""
+        ).strip(),
     },
     "issue_date": {
         "col_idx": 7,
@@ -256,6 +280,9 @@ PERMIT_COLUMNS = {
         "error_formula": lambda row, col: (
             f'IF(OR(NOT(ISNUMBER({col}{row})), {col}{row}=""), "Missing or Invalid Issue Date", "")'
         ),
+        "python_validator": lambda r: not str(
+            r.get("issue_date") or ""
+        ).strip(),
         "validation": {
             "validate": "date",
             "criteria": "greater than or equal to",
@@ -279,6 +306,11 @@ PERMIT_COLUMNS = {
             f'IF(OR({col}{row}="", NOT(ISNUMBER({col}{row}))), "Missing Amount", ""), '
             f'IF(AND(ISNUMBER({col}{row}), {col}{row}<1), "Amount must be at least 1", ""), '
             f'IF(AND(ISNUMBER({col}{row}), {col}{row}>2147483647), "Amount must be less than 2,147,483,647", "")'
+        ),
+        "python_validator": lambda r: (
+            pd.isna(r.get("amount"))
+            or not str(r.get("amount") or "").strip()
+            or not (1 <= float(r["amount"]) <= 2147483647)
         ),
         "validation": {
             "validate": "custom",
@@ -319,6 +351,10 @@ PERMIT_COLUMNS = {
             f'IF(LEN(TRIM({col}{row}))=0, "Missing Work Description", ""), '
             f'IF(LEN({col}{row})>2000, "Work Description > 2000 characters", "")'
         ),
+        "python_validator": lambda r: (
+            not str(r.get("work_description") or "").strip()
+            or len(str(r.get("work_description") or "")) > 2000
+        ),
         "validation": {
             "validate": "text length",
             "criteria": "between",
@@ -341,6 +377,10 @@ PERMIT_COLUMNS = {
         "error_formula": lambda row, col: (
             f'IF(LEN(TRIM({col}{row}))=0, "Missing Applicant", ""), '
             f'IF(LEN({col}{row})>50, "Applicant Name > 50 characters", "")'
+        ),
+        "python_validator": lambda r: (
+            not str(r.get("applicant") or "").strip()
+            or len(str(r.get("applicant") or "")) > 50
         ),
         "validation": {
             "validate": "text length",
@@ -388,6 +428,31 @@ PERMIT_COLUMNS_BY_IDX = sorted(
 
 # Number of columns to freeze on the left (Errors, Ready, PIN)
 FREEZE_COLS = 3
+
+
+def partition_permits(df: pd.DataFrame, chicago_pin_universe: pd.DataFrame):
+    """Split df into (upload_df, review_df) based on whether each row passes
+    all validations.  Derives checks from the python_validator key in each
+    PERMIT_COLUMNS entry so there is a single source of truth with error_formula.
+    Rows that pass every check go to upload_df; rows with any failure go to
+    review_df. PIN universe membership (the third IF in pin's error_formula)
+    requires external state, so it is checked here rather than in python_validator.
+    """
+    valid_pins = set(chicago_pin_universe["pin"].astype(str).str.zfill(14))
+
+    def row_has_error(row):
+        for col_def in PERMIT_COLUMNS_BY_IDX:
+            validator = col_def.get("python_validator")
+            if validator and validator(row):
+                return True
+        # PIN universe check (mirrors the third IF in pin's error_formula)
+        pin_val = str(row.get("pin") or "").replace("-", "").zfill(14)
+        if pin_val not in valid_pins:
+            return True
+        return False
+
+    mask = df.apply(row_has_error, axis=1)
+    return df[~mask].reset_index(drop=True), df[mask].reset_index(drop=True)
 
 
 def parse_args() -> tuple[str, str, bool]:
@@ -779,6 +844,13 @@ def deduplicate_permits(cursor, df, start_date, end_date):
         if col.get("src") and col.get("iasworld_name")
     }
     new_permits = df.copy()
+
+    # Stash the original amount before transformation. The iasworld-formatted
+    # copy is used only for the deduplication join; because "amount" maps to
+    # itself (src == iasworld_name), it would otherwise be dropped along with
+    # the other iasworld join columns at the end of this function.
+    original_amount = new_permits["amount"].copy()
+
     for workbook_key, iasworld_key in workbook_to_iasworld_col_map.items():
         new_permits[iasworld_key] = new_permits[workbook_key]
 
@@ -816,6 +888,12 @@ def deduplicate_permits(cursor, df, start_date, end_date):
     for iasworld_key in workbook_to_iasworld_col_map.values():
         true_new_permits = true_new_permits.drop(iasworld_key, axis=1)
 
+    # Restore the original amount values (integer dollars) now that the
+    # iasworld-formatted "amount" column has been dropped above.
+    true_new_permits["amount"] = original_amount.reindex(
+        true_new_permits.index
+    )
+
     return true_new_permits
 
 
@@ -844,17 +922,14 @@ def _build_textjoin_errors_formula(row: int) -> str:
     return f'=_xlfn.TEXTJOIN(", ", TRUE, {clauses})'
 
 
-def save_xlsx_files(df, file_base_name, chicago_pin_universe):
+def save_xlsx_files(df, file_name, chicago_pin_universe, checked=False):
+    """Write one workbook to `file_name` containing a Permits sheet and a
+    Universe of Valid PINs sheet.  When `checked` is True, all Ready
+    checkboxes are pre-checked (used for the upload file)."""
     df_all = df.reset_index(drop=True)
 
-    print(f"# rows total: {len(df_all)}")
+    print(f"  # rows: {len(df_all)}")
 
-    output_folder = (
-        datetime.today().date().strftime("files_for_review_%Y_%m_%d")
-    )
-    os.makedirs(output_folder, exist_ok=True)
-
-    file_name = os.path.join(output_folder, file_base_name + "permits.xlsx")
     workbook = xlsxwriter.Workbook(file_name)
 
     # Define the xlsxwriter format objects by the id of the
@@ -906,7 +981,9 @@ def save_xlsx_files(df, file_base_name, chicago_pin_universe):
                 continue
 
             if cell_type == "checkbox":
-                ws.insert_checkbox(xl_row, ci, False, get_fmt(FORMAT_CHECKBOX))
+                ws.insert_checkbox(
+                    xl_row, ci, checked, get_fmt(FORMAT_CHECKBOX)
+                )
                 continue
 
             # --- Source-value cells ---
@@ -995,6 +1072,11 @@ def save_xlsx_files(df, file_base_name, chicago_pin_universe):
             v = col_def.get("validation")
             if v is None:
                 continue
+            # The Ready column validation blocks checking when errors exist.
+            # In the upload file all rows are pre-checked and error-free, so
+            # skip it to avoid Excel resetting the checkbox state on open.
+            if checked and col_def["cell_type"] == "checkbox":
+                continue
             v = copy.deepcopy(v)
             show_error = v.pop("show_error", True)
             error_type = v.pop("error_type", "stop")
@@ -1064,7 +1146,7 @@ def save_xlsx_files(df, file_base_name, chicago_pin_universe):
     ws_pins.protect("")
 
     workbook.close()
-    print(f"Saved workbook to {file_name}")
+    print(f"  Saved to {file_name}")
 
 
 if __name__ == "__main__":
@@ -1131,6 +1213,31 @@ if __name__ == "__main__":
     else:
         permits_final = permits_with_links
 
-    file_base_name = gen_file_base_name(start_date, end_date)
+    upload_df, review_df = partition_permits(
+        permits_final, chicago_pin_universe
+    )
+    print(
+        f"Partition results — upload: {len(upload_df)}, review: {len(review_df)}"
+    )
 
-    save_xlsx_files(permits_final, file_base_name, chicago_pin_universe)
+    output_folder = (
+        datetime.today().date().strftime("files_for_review_%Y_%m_%d")
+    )
+    os.makedirs(output_folder, exist_ok=True)
+
+    base = f"{start_date}_to_{end_date}_chicago_"
+
+    print(f"Writing upload file ({len(upload_df)} rows):")
+    save_xlsx_files(
+        upload_df,
+        os.path.join(output_folder, f"upload_{base}permits.xlsx"),
+        chicago_pin_universe,
+        checked=True,
+    )
+
+    print(f"Writing review file ({len(review_df)} rows):")
+    save_xlsx_files(
+        review_df,
+        os.path.join(output_folder, f"review_{base}permits.xlsx"),
+        chicago_pin_universe,
+    )

--- a/chicago/permit_cleaning.py
+++ b/chicago/permit_cleaning.py
@@ -118,10 +118,10 @@ FORMAT_HYPERLINK_UNLOCKED = {**_unlocked, **_hyperlink}
 #       whenever those formulas are updated.
 #
 #   python_validator (callable, optional)
-#       A lambda(row_series) -> bool that returns True if this column's value
-#       in the given DataFrame row would trigger any clause in error_formula.
-#       This runs in parallel to the error_formula and should be updated
-#       whenever those formulas are updated.
+#       A lambda(row_series, colname) -> bool that returns True if this column's
+#       value in the given DataFrame row would trigger any clause in
+#       error_formula. This runs in parallel to the error_formula and should be
+#       updated whenever those formulas are updated.
 #
 #   validation (dict, optional)
 #       An xlsxwriter data_validation() options dict to apply to the column's

--- a/chicago/permit_cleaning.py
+++ b/chicago/permit_cleaning.py
@@ -428,8 +428,7 @@ FREEZE_COLS = 3
 
 
 def partition_permits(
-    df: pd.DataFrame,
-    chicago_pin_universe: pd.DataFrame
+    df: pd.DataFrame, chicago_pin_universe: pd.DataFrame
 ) -> tuple[pd.DataFrame, pd.DataFrame]:
     """Split df into (upload_df, review_df) based on whether each row passes
     all validations.  Derives checks from the python_validator key in each


### PR DESCRIPTION
This adds in python checks to provide the same validation as it does in excel and creates two separate outputs, `upload` and `review` for our stakeholder.